### PR TITLE
Add extras cmake files

### DIFF
--- a/tesseract_monitoring/CMakeLists.txt
+++ b/tesseract_monitoring/CMakeLists.txt
@@ -46,6 +46,8 @@ catkin_package(
     orocos_kdl
     tesseract_common
     tesseract_environment
+  CFG_EXTRAS
+    tesseract_monitoring-extras.cmake
 )
 
 include_directories(

--- a/tesseract_monitoring/cmake/tesseract_monitoring-extras.cmake.in
+++ b/tesseract_monitoring/cmake/tesseract_monitoring-extras.cmake.in
@@ -1,0 +1,7 @@
+# Since catkin does not support modern cmake and as a result linking leveraging targets causes
+# these depends to not be include in the generated cmake package config.
+include(CMakeFindDependencyMacro)
+find_dependency(tesseract_environment)
+find_dependency(orocos_kdl)
+find_dependency(tesseract_common)
+find_dependency(Eigen3)

--- a/tesseract_planning_server/CMakeLists.txt
+++ b/tesseract_planning_server/CMakeLists.txt
@@ -34,6 +34,8 @@ catkin_package(
     tesseract_command_language
     tesseract_process_managers
     tesseract_common
+  CFG_EXTRAS
+    tesseract_planning_server-extras.cmake
 )
 
 # Load variable for clang tidy args, compiler options and cxx version

--- a/tesseract_planning_server/cmake/tesseract_planning_server-extras.cmake.in
+++ b/tesseract_planning_server/cmake/tesseract_planning_server-extras.cmake.in
@@ -1,0 +1,8 @@
+# Since catkin does not support modern cmake and as a result linking leveraging targets causes
+# these depends to not be include in the generated cmake package config.
+include(CMakeFindDependencyMacro)
+find_dependency(Boost)
+find_dependency(Eigen3)
+find_dependency(tesseract_command_language)
+find_dependency(tesseract_process_managers)
+find_dependency(tesseract_common)

--- a/tesseract_ros_examples/CMakeLists.txt
+++ b/tesseract_ros_examples/CMakeLists.txt
@@ -25,7 +25,10 @@ find_package(trajopt_sqp REQUIRED)
 find_package(trajopt_ifopt REQUIRED)
 find_package(PCL REQUIRED COMPONENTS core features filters io segmentation surface)
 
-catkin_package()
+catkin_package(
+  CFG_EXTRAS
+    tesseract_ros_examples-extras.cmake
+)
 
 # Load variable for clang tidy args, compiler options and cxx version
 tesseract_variables()

--- a/tesseract_ros_examples/cmake/tesseract_ros_examples-extras.cmake.in
+++ b/tesseract_ros_examples/cmake/tesseract_ros_examples-extras.cmake.in
@@ -1,0 +1,17 @@
+# Since catkin does not support modern cmake and as a result linking leveraging targets causes
+# these depends to not be include in the generated cmake package config.
+include(CMakeFindDependencyMacro)
+find_dependency(tesseract_environment)
+find_dependency(tesseract_command_language)
+find_dependency(tesseract_motion_planners)
+find_dependency(tesseract_process_managers)
+find_dependency(tesseract_common)
+find_dependency(tesseract_collision)
+find_dependency(trajopt_sqp)
+find_dependency(trajopt_ifopt)
+
+if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
+    find_package(PCL REQUIRED COMPONENTS core features filters io segmentation surface)
+else()
+    find_dependency(PCL REQUIRED COMPONENTS core features filters io segmentation surface)
+endif()

--- a/tesseract_rosutils/CMakeLists.txt
+++ b/tesseract_rosutils/CMakeLists.txt
@@ -57,6 +57,8 @@ catkin_package(
     tesseract_environment
     tesseract_process_managers
     yaml-cpp
+  CFG_EXTRAS
+    tesseract_rosutils-extras.cmake
 )
 
 # Load variable for clang tidy args, compiler options and cxx version

--- a/tesseract_rosutils/cmake/tesseract_rosutils-extras.cmake.in
+++ b/tesseract_rosutils/cmake/tesseract_rosutils-extras.cmake.in
@@ -1,0 +1,16 @@
+# Since catkin does not support modern cmake and as a result linking leveraging targets causes
+# these depends to not be include in the generated cmake package config.
+include(CMakeFindDependencyMacro)
+find_dependency(Boost)
+find_dependency(Eigen3)
+find_dependency(tesseract_collision)
+find_dependency(tesseract_common)
+find_dependency(tesseract_environment)
+find_dependency(tesseract_geometry) # This should not be required, must be doing something wrong when creating targets
+find_dependency(tesseract_motion_planners)
+find_dependency(tesseract_scene_graph)
+find_dependency(tesseract_srdf)
+find_dependency(tesseract_visualization)
+find_dependency(tesseract_command_language)
+find_dependency(tesseract_process_managers)
+find_dependency(yaml-cpp)

--- a/tesseract_rviz/CMakeLists.txt
+++ b/tesseract_rviz/CMakeLists.txt
@@ -79,6 +79,8 @@ catkin_package(
     tesseract_common
     tesseract_visualization
     tesseract_motion_planners
+  CFG_EXTRAS
+    tesseract_rviz-extras.cmake
 )
 
 # Load variable for clang tidy args, compiler options and cxx version

--- a/tesseract_rviz/cmake/tesseract_rviz-extras.cmake.in
+++ b/tesseract_rviz/cmake/tesseract_rviz-extras.cmake.in
@@ -1,0 +1,15 @@
+# Since catkin does not support modern cmake and as a result linking leveraging targets causes
+# these depends to not be include in the generated cmake package config.
+include(CMakeFindDependencyMacro)
+
+if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
+    find_package(Boost REQUIRED thread date_time system filesystem)
+else()
+    find_dependency(Boost REQUIRED thread date_time system filesystem)
+endif()
+
+find_dependency(tesseract_environment)
+find_dependency(tesseract_motion_planners)
+find_dependency(tesseract_common)
+find_dependency(tesseract_visualization)
+find_dependency(Eigen3)


### PR DESCRIPTION
It appears catkin does not handle DEPENDS when leveraging modern cmake targets for linking.