### PR TITLE
Fix toMsg and fromMsg for capsule

### DIFF
--- a/tesseract_msgs/msg/Geometry.msg
+++ b/tesseract_msgs/msg/Geometry.msg
@@ -2,6 +2,7 @@
 
 uint8 SPHERE=1
 uint8 CYLINDER=2
+uint8 CAPSULE=10
 uint8 CONE=3
 uint8 BOX=4
 uint8 PLANE=5
@@ -18,6 +19,9 @@ float64 sphere_radius
 
 # CYLINDER
 float64[2] cylinder_dimensions
+
+# CAPSULE
+float64[2] capsule_dimensions
 
 # CONE (radius, length)
 float64[2] cone_dimensions

--- a/tesseract_rosutils/CMakeLists.txt
+++ b/tesseract_rosutils/CMakeLists.txt
@@ -116,4 +116,16 @@ if(CATKIN_ENABLE_TESTING)
   target_include_directories(${PROJECT_NAME}_unit SYSTEM PRIVATE
       ${catkin_INCLUDE_DIRS}
       ${EIGEN3_INCLUDE_DIRS})
+
+  catkin_add_gtest(${PROJECT_NAME}_geometry_msg_conversions test/${PROJECT_NAME}_geometry_msg_conversions.cpp)
+  target_link_libraries(${PROJECT_NAME}_geometry_msg_conversions GTest::GTest GTest::Main tesseract::tesseract_support tesseract::tesseract_scene_graph tesseract::tesseract_geometry tesseract::tesseract_collision_core tesseract::tesseract_visualization tesseract::tesseract_common tesseract::tesseract_motion_planners_core ${PROJECT_NAME} ${catkin_LIBRARIES})
+  target_compile_options(${PROJECT_NAME}_geometry_msg_conversions PRIVATE ${TESSERACT_COMPILE_OPTIONS})
+  target_clang_tidy(${PROJECT_NAME}_geometry_msg_conversions ARGUMENTS ${TESSERACT_CLANG_TIDY_ARGS} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
+  target_cxx_version(${PROJECT_NAME}_geometry_msg_conversions PUBLIC VERSION 17)
+  target_include_directories(${PROJECT_NAME}_geometry_msg_conversions PRIVATE
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+      "$<INSTALL_INTERFACE:include>")
+  target_include_directories(${PROJECT_NAME}_geometry_msg_conversions SYSTEM PRIVATE
+      ${catkin_INCLUDE_DIRS}
+      ${EIGEN3_INCLUDE_DIRS})
 endif()

--- a/tesseract_rosutils/src/utils.cpp
+++ b/tesseract_rosutils/src/utils.cpp
@@ -316,6 +316,15 @@ bool toMsg(tesseract_msgs::Geometry& geometry_msgs, const tesseract_geometry::Ge
       geometry_msgs.cylinder_dimensions[1] = cylinder.getLength();
       break;
     }
+    case tesseract_geometry::GeometryType::CAPSULE:
+    {
+      const auto& capsule = static_cast<const tesseract_geometry::Capsule&>(geometry);
+
+      geometry_msgs.type = tesseract_msgs::Geometry::CAPSULE;
+      geometry_msgs.capsule_dimensions[0] = capsule.getRadius();
+      geometry_msgs.capsule_dimensions[1] = capsule.getLength();
+      break;
+    }
     case tesseract_geometry::GeometryType::CONE:
     {
       const auto& cone = static_cast<const tesseract_geometry::Cone&>(geometry);
@@ -492,6 +501,11 @@ bool fromMsg(tesseract_geometry::Geometry::Ptr& geometry, const tesseract_msgs::
   {
     geometry = std::make_shared<tesseract_geometry::Cylinder>(geometry_msg.cylinder_dimensions[0],
                                                               geometry_msg.cylinder_dimensions[1]);
+  }
+  else if (geometry_msg.type == tesseract_msgs::Geometry::CAPSULE)
+  {
+    geometry = std::make_shared<tesseract_geometry::Capsule>(geometry_msg.capsule_dimensions[0],
+                                                             geometry_msg.capsule_dimensions[1]);
   }
   else if (geometry_msg.type == tesseract_msgs::Geometry::CONE)
   {

--- a/tesseract_rosutils/test/tesseract_rosutils_geometry_msg_conversions.cpp
+++ b/tesseract_rosutils/test/tesseract_rosutils_geometry_msg_conversions.cpp
@@ -1,0 +1,166 @@
+/**
+ * @file tesseract_geometry_serialization_unit.cpp
+ * @brief Tests serialization of geometry
+ *
+ * @author Levi Armstrong
+ * @author Matthew Powelson
+ * @date March 16, 2022
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <gtest/gtest.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/unit_test_utils.h>
+#include <tesseract_common/utils.h>
+#include <tesseract_geometry/geometries.h>
+#include <tesseract_geometry/mesh_parser.h>
+#include <tesseract_support/tesseract_support_resource_locator.h>
+#include <tesseract_rosutils/utils.h>
+
+using namespace tesseract_geometry;
+using namespace tesseract_rosutils;
+
+/**
+ * @brief Tests if the toMsg and fromMsg result in the same object
+ * @param geometry Input msg
+ */
+inline void testToMsgFromMsg(const tesseract_geometry::Geometry& object)
+{
+  // Serialize to ros message
+  tesseract_msgs::Geometry msg;
+  EXPECT_TRUE(toMsg(msg, object));
+
+  // Deserialize to object
+  tesseract_geometry::Geometry::Ptr object_new;
+  EXPECT_TRUE(fromMsg(object_new, msg));
+
+  // Check for equality
+  EXPECT_TRUE(object == *object_new);
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, Box)  // NOLINT
+{
+  auto object = std::make_shared<Box>(1, 2, 3);
+  testToMsgFromMsg(*object);
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, Capsule)  // NOLINT
+{
+  auto object = std::make_shared<Capsule>(1, 2);
+  testToMsgFromMsg(*object);
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, Cone)  // NOLINT
+{
+  auto object = std::make_shared<Cone>(1.1, 2.2);
+  testToMsgFromMsg(*object);
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, ConvexMesh)  // NOLINT
+{
+  std::string path = std::string(TESSERACT_SUPPORT_DIR) + "/meshes/sphere_p25m.stl";
+  tesseract_common::TesseractSupportResourceLocator locator;
+  auto object = tesseract_geometry::createMeshFromResource<tesseract_geometry::ConvexMesh>(
+      locator.locateResource(path), Eigen::Vector3d(.1, .2, .3), true, true, true, true, true);
+  testToMsgFromMsg(*object.back());
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, Cylinder)  // NOLINT
+{
+  auto object = std::make_shared<Cylinder>(3.3, 4.4);
+  testToMsgFromMsg(*object);
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, Mesh)  // NOLINT
+{
+  std::string path = std::string(TESSERACT_SUPPORT_DIR) + "/meshes/sphere_p25m.stl";
+  tesseract_common::TesseractSupportResourceLocator locator;
+  auto object = tesseract_geometry::createMeshFromResource<tesseract_geometry::Mesh>(
+      locator.locateResource(path), Eigen::Vector3d(.1, .2, .3), true, true, true, true, true);
+  testToMsgFromMsg(*object.back());
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, Octree)  // NOLINT
+{
+  struct TestPointCloud
+  {
+    struct point
+    {
+      point(double x, double y, double z) : x(x), y(y), z(z) {}
+      double x;
+      double y;
+      double z;
+    };
+
+    std::vector<point> points;
+  };
+
+  TestPointCloud pc;
+  pc.points.emplace_back(.5, 0.5, 0.5);
+  pc.points.emplace_back(-.5, -0.5, -0.5);
+  pc.points.emplace_back(-.5, 0.5, 0.5);
+  {
+    auto object =
+        std::make_shared<tesseract_geometry::Octree>(pc, 1, tesseract_geometry::Octree::SubType::BOX, false, true);
+    testToMsgFromMsg(*object);
+  }
+  {
+    auto object =
+        std::make_shared<tesseract_geometry::Octree>(pc, 1, tesseract_geometry::Octree::SubType::BOX, false, false);
+    testToMsgFromMsg(*object);
+  }
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, Plane)  // NOLINT
+{
+  auto object = std::make_shared<Plane>(1.1, 2, 3.3, 4);
+  testToMsgFromMsg(*object);
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, PolygonMesh)  // NOLINT
+{
+  std::string path = std::string(TESSERACT_SUPPORT_DIR) + "/meshes/sphere_p25m.stl";
+  tesseract_common::TesseractSupportResourceLocator locator;
+  auto object = tesseract_geometry::createMeshFromResource<tesseract_geometry::PolygonMesh>(
+      locator.locateResource(path), Eigen::Vector3d(.1, .2, .3), true, true, true, true, true);
+  testToMsgFromMsg(*object.back());
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, SDFMesh)  // NOLINT
+{
+  std::string path = std::string(TESSERACT_SUPPORT_DIR) + "/meshes/sphere_p25m.stl";
+  tesseract_common::TesseractSupportResourceLocator locator;
+  auto object = tesseract_geometry::createMeshFromResource<tesseract_geometry::SDFMesh>(
+      locator.locateResource(path), Eigen::Vector3d(.1, .2, .3), true, true, true, true, true);
+  testToMsgFromMsg(*object.back());
+}
+
+TEST(TesseractRosutilsGeometryMsgConversions, Sphere)  // NOLINT
+{
+  auto object = std::make_shared<Sphere>(3.3);
+  testToMsgFromMsg(*object);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
I also added unit tests. They are basically the tests from tesseract_geometry serialization just modified for this.