### PR TITLE
Draft: Implement planar joints in CurrentStateMonitor

### DIFF
--- a/tesseract_monitoring/demos/demo_scene.rviz
+++ b/tesseract_monitoring/demos/demo_scene.rviz
@@ -1,0 +1,158 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 408
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: tesseract_rviz/TesseractEnvironment
+      Enabled: true
+      Environment Properties:
+        Display Mode: URDF
+        Joint State Topic: /joint_states
+        Monitor Topic: /tesseract_environment
+        Snapshot Topic: /tesseract_environment_snapshot
+        URDF Parameter: robot_description
+        Value: ""
+      Name: TesseractEnvironment
+      Value: true
+      tesseract::EnvMonitorJointStateTopic: /joint_states
+      tesseract::EnvMonitorMode: URDF
+      tesseract::EnvMonitorSnapshotTopic: /tesseract_environment
+      tesseract::EnvMonitorTopic: /tesseract_environment
+      tesseract::EnvMonitorURDFDescription: robot_description
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base_link:
+          Value: true
+        world:
+          Value: true
+      Marker Alpha: 1
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        world:
+          base_link:
+            {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 6.814720153808594
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Field of View: 0.7853981852531433
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.785398006439209
+      Target Frame: <Fixed Frame>
+      Yaw: 0.785398006439209
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1043
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000015600000375fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000223000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000280054006500730073006500720061006300740045006e007600690072006f006e006d0065006e007400000001c2000001f00000014c00fffffffb000000280054006500730073006500720061006300740045006e007600690072006f006e006d0065006e007401000002660000014c0000014c00ffffff000000010000010f00000375fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d00000375000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007380000003efc0100000002fb0000000800540069006d0065010000000000000738000003bc00fffffffb0000000800540069006d00650100000000000004500000000000000000000004c70000037500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  TesseractEnvironment:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1848
+  X: 72
+  Y: 0

--- a/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
+++ b/tesseract_monitoring/include/tesseract_monitoring/current_state_monitor.h
@@ -48,6 +48,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <unordered_map>
 #include <map>
 #include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_environment/environment.h>
@@ -185,6 +187,22 @@ private:
   void jointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state);
   bool isPassiveOrMimicDOF(const std::string& dof) const;
 
+  /**
+   * @brief getPlanerJointNames
+   * @details Assumes the base joint name (in the urdf) does not include the substring _x_planar
+   * @param all_joint_names All joints in the environment
+   * @return Base joint names of the planar joints (the name in the urdf)
+   */
+  std::vector<std::string> getPlanerJointNames(const std::vector<std::string>& all_joint_names) const;
+
+  /**
+   * @brief Update a specified joint in env_state_
+   * @param joint_name Name of the joint to update
+   * @param joint_value Value of the joint to update
+   * @return Whether or not this updated a joint
+   */
+  bool updateJoint(const std::string& joint_name, double joint_value, const ros::Time& stamp);
+
   ros::NodeHandle nh_;
   tesseract_environment::Environment::ConstPtr env_;
   tesseract_scene_graph::SceneState env_state_;
@@ -195,6 +213,9 @@ private:
   ros::Time monitor_start_time_;
   double error_;
   ros::Subscriber joint_state_subscriber_;
+  std::vector<std::string> tf_updated_joints_;  /// Joints updated from TF instead of joint_states
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
   tf2_ros::TransformBroadcaster tf_broadcaster_;
   ros::Time current_state_time_;
   ros::Time last_tf_update_;

--- a/tesseract_monitoring/launch/demo_planar_joint.launch
+++ b/tesseract_monitoring/launch/demo_planar_joint.launch
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Load universal robot description format (URDF) -->
+    <param name="robot_description" textfile="$(find tesseract_support)/urdf/lbr_iiwa_14_r820_with_planar.urdf" />
+
+    <!-- The semantic description that corresponds to the URDF -->
+    <param name="robot_description_semantic" textfile="$(find tesseract_support)/urdf/lbr_iiwa_14_r820.srdf" />
+
+    <!-- Launch visualization -->
+    <node pkg="rviz" type="rviz" name="rviz" args="-d $(find tesseract_monitoring)/demos/demo_scene.rviz" />
+
+    <!-- STATE PUBLISHER -->
+    <node name="joint_state_publisher_gui"
+          pkg="joint_state_publisher_gui"
+          type="joint_state_publisher_gui" >
+    </node>
+
+    <node pkg="tf" type="static_transform_publisher" name="world_broadcaster" args="0.1 0.2 0.0 0.0 0.0 0.3  world base_link 1"/>
+
+</launch>


### PR DESCRIPTION
Requires [tesseract #915](https://github.com/tesseract-robotics/tesseract/pull/915). This listens to TF to update planar joints. We should probably do some more performance testing on this before merging. TFBuffers can add some CPU overhead. We could consider starting the buffer only if `!tf_updated_joints_.empty()`